### PR TITLE
fix: correct validation and type casting in Json class

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -17,8 +17,10 @@
   },
   "imports": {
     "@cross/test": "jsr:@cross/test@^0.0.9",
+    "@ryoppippi/limo": "./mod.ts",
     "@std/assert": "jsr:@std/assert@^0.226.0",
-    "@ryoppippi/limo": "./mod.ts"
+    "@std/jsonc": "jsr:@std/jsonc@^0.224.2",
+    "jsonc-parser": "npm:jsonc-parser@^3.2.1"
   },
   "exports": "./mod.ts",
   "publish": {

--- a/deno.lock
+++ b/deno.lock
@@ -6,8 +6,11 @@
       "jsr:@cross/test@^0.0.9": "jsr:@cross/test@0.0.9",
       "jsr:@std/assert@^0.226.0": "jsr:@std/assert@0.226.0",
       "jsr:@std/internal@^1.0.0": "jsr:@std/internal@1.0.0",
+      "jsr:@std/json@^0.224.1": "jsr:@std/json@0.224.1",
+      "jsr:@std/jsonc@^0.224.2": "jsr:@std/jsonc@0.224.2",
       "npm:@types/node": "npm:@types/node@18.16.19",
-      "npm:cronstrue": "npm:cronstrue@2.50.0"
+      "npm:cronstrue": "npm:cronstrue@2.50.0",
+      "npm:jsonc-parser@^3.2.1": "npm:jsonc-parser@3.2.1"
     },
     "jsr": {
       "@cross/runtime@1.0.0": {
@@ -27,6 +30,15 @@
       },
       "@std/internal@1.0.0": {
         "integrity": "ac6a6dfebf838582c4b4f61a6907374e27e05bedb6ce276e0f1608fe84e7cd9a"
+      },
+      "@std/json@0.224.1": {
+        "integrity": "2a18a8000707190e467f94b2732f6f88a3094db823765d8c58925bb5efeac29a"
+      },
+      "@std/jsonc@0.224.2": {
+        "integrity": "b7344f8c5ea95394a8421c6060324717c6922661ca26a9f9d0ac5803689739ab",
+        "dependencies": [
+          "jsr:@std/json@^0.224.1"
+        ]
       }
     },
     "npm": {
@@ -37,6 +49,10 @@
       "cronstrue@2.50.0": {
         "integrity": "sha512-ULYhWIonJzlScCCQrPUG5uMXzXxSixty4djud9SS37DoNxDdkeRocxzHuAo4ImRBUK+mAuU5X9TSwEDccnnuPg==",
         "dependencies": {}
+      },
+      "jsonc-parser@3.2.1": {
+        "integrity": "sha512-AilxAyFOAcK5wA1+LeaySVBrHsGQvUFCDWXKpZjzaL0PqW+xfBOttn8GNtWKFWqneyMZj41MWF9Kl6iPWLwgOA==",
+        "dependencies": {}
       }
     }
   },
@@ -44,7 +60,9 @@
   "workspace": {
     "dependencies": [
       "jsr:@cross/test@^0.0.9",
-      "jsr:@std/assert@^0.226.0"
+      "jsr:@std/assert@^0.226.0",
+      "jsr:@std/jsonc@^0.224.2",
+      "npm:jsonc-parser@^3.2.1"
     ]
   }
 }

--- a/mod.ts
+++ b/mod.ts
@@ -113,10 +113,10 @@ export class Json<T> implements Limo<T> {
     if (existsSync(this.#path)) {
       const text = readFileSync(this.#path, { encoding: "utf8" });
       const json = JSON.parse(text) as unknown;
-      if (validator == null || !validator(json)) {
+      if (validator != null && !validator(json)) {
         throw new Error(`Invalid data: ${text}`);
       }
-      return json;
+      return json as T;
     }
     return undefined;
   }

--- a/mod.ts
+++ b/mod.ts
@@ -1,4 +1,5 @@
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import * as jsonc_parser from "jsonc-parser";
 
 type Validator<T> = (value: unknown) => value is T;
 interface Limo<T> {
@@ -127,5 +128,77 @@ export class Json<T> implements Limo<T> {
     }
 
     writeFileSync(this.#path, JSON.stringify(this.#data, null, 2));
+  }
+}
+
+export class Jsonc<T> implements Limo<T> {
+  #data: T | undefined;
+  #old_data: T | undefined;
+  #path: string;
+  #text: string | undefined;
+
+  constructor(
+    path: string,
+    validator?: Validator<T>,
+  ) {
+    this.#path = path;
+    const { jsonc, text } = this._read(validator);
+    this.#data = this.#old_data = jsonc;
+    this.#text = text;
+  }
+
+  [Symbol.dispose]() {
+    this._write();
+  }
+
+  get data(): T | undefined {
+    return this.#data;
+  }
+
+  set data(value: T) {
+    this.#data = value;
+  }
+
+  private _read(validator?: Validator<T>) {
+    if (existsSync(this.#path)) {
+      const text = readFileSync(this.#path, { encoding: "utf8" });
+      const jsonc = jsonc_parser.parse(text);
+      if (validator != null && !validator(jsonc)) {
+        throw new Error(`Invalid data: ${text}`);
+      }
+      return { jsonc: jsonc as T, text };
+    }
+    return { jsonc: undefined, text: undefined };
+  }
+
+  private _write() {
+    if (this.#data == null) {
+      return;
+    }
+
+    const text = this.#text ?? "";
+
+    const edits: jsonc_parser.EditResult[] = [];
+
+    for (const key of Object.keys(this.#old_data ?? {})) {
+      if (Object.hasOwn(this.#data, key)) {
+        continue;
+      }
+      const edit = jsonc_parser.modify(text, [key], undefined, {});
+      edits.push(edit);
+    }
+
+    for (const [key, value] of Object.entries(this.#data)) {
+      const edit = jsonc_parser.modify(text, [key], value, {});
+      edits.push(edit);
+    }
+
+    const newText = jsonc_parser.applyEdits(text, edits.flat());
+
+    const formatted = jsonc_parser.applyEdits(
+      newText,
+      jsonc_parser.format(newText, undefined, {}),
+    );
+    writeFileSync(this.#path, formatted);
   }
 }

--- a/mod_test.ts
+++ b/mod_test.ts
@@ -1,11 +1,12 @@
 import { test } from "@cross/test";
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertThrows } from "@std/assert";
 
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { mkdirSync, readFileSync } from "node:fs";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import * as jsonc_parser from "jsonc-parser";
 
-import { Json, Text } from "./mod.ts";
+import { Json, Jsonc, Text } from "./mod.ts";
 
 function prepareTmpdir() {
   const randomStr = Math.random().toString(36).substring(7);
@@ -54,4 +55,87 @@ test("Json with validator", () => {
   const data = readFileSync(filepath, "utf-8");
   const json = JSON.parse(data);
   assertEquals(json, { hello: "world" });
+});
+
+test("Jsonc without validator", () => {
+  const td = prepareTmpdir();
+  const filepath = join(td, "file.jsonc");
+  {
+    using json = new Jsonc(filepath);
+    json.data = { hello: "world" };
+  }
+
+  const data = readFileSync(filepath, "utf-8");
+  const jsonc = jsonc_parser.parse(data);
+
+  assertEquals(jsonc, { hello: "world" });
+});
+
+test("Jsonc with prepared file and without validator", () => {
+  const td = prepareTmpdir();
+  const filepath = join(td, "file.jsonc");
+  const dummyJsonc = '{"foo": "bar", } // comment';
+  writeFileSync(filepath, dummyJsonc);
+
+  {
+    using json = new Jsonc(filepath);
+
+    assertEquals(json.data, { foo: "bar" });
+  }
+});
+
+test("Jsonc with validator", () => {
+  const td = prepareTmpdir();
+  const filepath = join(td, "file.jsonc");
+
+  function validator(data: unknown): data is { hello: string } {
+    return typeof data === "object" && data != null && "hello" in data;
+  }
+  {
+    using json = new Jsonc(filepath, validator);
+    json.data = { hello: "world" };
+  }
+
+  const data = readFileSync(filepath, "utf-8");
+  const jsonc = jsonc_parser.parse(data);
+  assertEquals(jsonc, { hello: "world" });
+});
+
+test("Jsonc with invalid data and validator", () => {
+  const td = prepareTmpdir();
+  const filepath = join(td, "file.jsonc");
+
+  function validator(data: unknown): data is { hello: string } {
+    return typeof data === "object" && data != null && "hello" in data;
+  }
+
+  writeFileSync(filepath, '{"foo": "bar"}');
+
+  assertThrows(() => {
+    using json = new Jsonc(filepath, validator);
+    assertEquals(json.data, { hello: "world" });
+  });
+});
+
+test("Jsonc with prepared file and valid data and validator", () => {
+  const td = prepareTmpdir();
+  const filepath = join(td, "file.jsonc");
+  const dummyJsonc = '{"hello": "world"} // comment';
+
+  writeFileSync(filepath, dummyJsonc);
+
+  function validator(data: unknown): data is { hello?: string; foo?: string } {
+    return typeof data === "object" && data != null && "hello" in data;
+  }
+
+  {
+    using json = new Jsonc(filepath, validator);
+    assertEquals(json.data, { hello: "world" });
+    json.data = { foo: "bar" };
+  }
+
+  const data = readFileSync(filepath, "utf-8");
+
+  const jsonc = jsonc_parser.parse(data);
+  assertEquals(jsonc, { foo: "bar" });
 });


### PR DESCRIPTION
The validation condition in the Json class was incorrect, causing it to
throw an error when the validator was null. This has been fixed to only
throw an error when the validator is not null and the validation fails.

Additionally, the return type of the json object was not being cast to
the generic type T. This has been corrected to ensure type safety.