### PR TITLE
feat: Add options for validation and existence check

### DIFF
--- a/mod_test.ts
+++ b/mod_test.ts
@@ -48,7 +48,7 @@ test("Json with validator", () => {
     return typeof data === "object" && data != null && "hello" in data;
   }
   {
-    using json = new Json(filepath, validator);
+    using json = new Json(filepath, { validator });
     json.data = { hello: "world" };
   }
 
@@ -92,7 +92,7 @@ test("Jsonc with validator", () => {
     return typeof data === "object" && data != null && "hello" in data;
   }
   {
-    using json = new Jsonc(filepath, validator);
+    using json = new Jsonc(filepath, { validator });
     json.data = { hello: "world" };
   }
 
@@ -112,7 +112,7 @@ test("Jsonc with invalid data and validator", () => {
   writeFileSync(filepath, '{"foo": "bar"}');
 
   assertThrows(() => {
-    using json = new Jsonc(filepath, validator);
+    using json = new Jsonc(filepath, { validator });
     assertEquals(json.data, { hello: "world" });
   });
 });
@@ -129,7 +129,7 @@ test("Jsonc with prepared file and valid data and validator", () => {
   }
 
   {
-    using json = new Jsonc(filepath, validator);
+    using json = new Jsonc(filepath, { validator });
     assertEquals(json.data, { hello: "world" });
     json.data = { foo: "bar" };
   }


### PR DESCRIPTION
This commit introduces an `Options` interface that includes a `validator`
and `allowNoExist` properties. The `validator` is used to validate the
data read from the file, and `allowNoExist` determines whether an error
should be thrown if the file does not exist.

The `Options` interface is used in the `Text`, `Json`, and `Jsonc` classes,
replacing the previous `validator` argument in the constructors. The
`resolveOptions` function is introduced to provide default values for
the options.

The unit tests are updated to use the new `Options` interface.

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review

- [ ] Did you implement the changes in the correct branch?
- [ ] Is JSDocs for your new implementation up to date?
- [ ] Did you add tests for your changes?
- [ ] Did you update the documentation?
- [ ] Did all CI checks pass?
