### PR TITLE
feat: Add YAML support to Limo

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -21,6 +21,7 @@
     "@std/assert": "jsr:@std/assert@^0.226.0",
     "@std/jsonc": "jsr:@std/jsonc@^0.224.2",
     "@std/toml": "jsr:@std/toml@^0.224.1",
+    "@std/yaml": "jsr:@std/yaml@^0.224.1",
     "jsonc-parser": "npm:jsonc-parser@^3.2.1"
   },
   "exports": "./mod.ts",

--- a/deno.lock
+++ b/deno.lock
@@ -10,6 +10,7 @@
       "jsr:@std/json@^0.224.1": "jsr:@std/json@0.224.1",
       "jsr:@std/jsonc@^0.224.2": "jsr:@std/jsonc@0.224.2",
       "jsr:@std/toml@^0.224.1": "jsr:@std/toml@0.224.1",
+      "jsr:@std/yaml@^0.224.1": "jsr:@std/yaml@0.224.1",
       "npm:@types/node": "npm:@types/node@18.16.19",
       "npm:cronstrue": "npm:cronstrue@2.50.0",
       "npm:jsonc-parser@^3.2.1": "npm:jsonc-parser@3.2.1"
@@ -50,6 +51,9 @@
         "dependencies": [
           "jsr:@std/collections@^1.0.0-rc.1"
         ]
+      },
+      "@std/yaml@0.224.1": {
+        "integrity": "cbb444acccce7ea34b9ef6678bff84c18eba89b790e52dd098def8dae313f0b2"
       }
     },
     "npm": {
@@ -74,6 +78,7 @@
       "jsr:@std/assert@^0.226.0",
       "jsr:@std/jsonc@^0.224.2",
       "jsr:@std/toml@^0.224.1",
+      "jsr:@std/yaml@^0.224.1",
       "npm:jsonc-parser@^3.2.1"
     ]
   }


### PR DESCRIPTION
This commit introduces YAML support to the Limo library. A new class
'Yaml' has been added which allows reading and writing of YAML files.
The Yaml class also supports validation of data similar to other classes
in the library. Corresponding unit tests have been added to ensure the
correctness of the new functionality.

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review

- [ ] Did you implement the changes in the correct branch?
- [ ] Is JSDocs for your new implementation up to date?
- [ ] Did you add tests for your changes?
- [ ] Did you update the documentation?
- [ ] Did all CI checks pass?
