### PR TITLE
feat: Move permissions in release.yaml

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,9 +8,6 @@ on:
     tags:
       - "*"
 
-permissions:
-  contents: write
-
 jobs:
   jsr:
     runs-on: ubuntu-latest
@@ -29,6 +26,8 @@ jobs:
           deno run -A jsr:@david/publish-on-tag@0.1.3
 
   release:
+    permissions:
+      contents: write
     needs:
       - jsr
     runs-on: ubuntu-latest


### PR DESCRIPTION
The permissions block in the release.yaml workflow file has been moved
from the global scope to the specific 'release' job. This change
restricts the write permissions to the 'release' job only, enhancing
the security of the workflow.

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review

- [ ] Did you implement the changes in the correct branch?
- [ ] Is JSDocs for your new implementation up to date?
- [ ] Did you add tests for your changes?
- [ ] Did you update the documentation?
- [ ] Did all CI checks pass?
