### PR TITLE
chore: update Deno to v2.4.4

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,30 +1,30 @@
 changelog:
   exclude:
     labels:
-      - 'Type: Meta'
-      - 'Type: Question'
-      - 'Type: Release'
+      - "Type: Meta"
+      - "Type: Question"
+      - "Type: Release"
 
   categories:
     - title: Security Fixes
-      labels: ['Type: Security']
+      labels: ["Type: Security"]
     - title: Breaking Changes
-      labels: ['Type: Breaking Change']
+      labels: ["Type: Breaking Change"]
     - title: Features
-      labels: ['Type: Feature']
+      labels: ["Type: Feature"]
     - title: Bug Fixes
-      labels: ['Type: Bug']
+      labels: ["Type: Bug"]
     - title: Documentation
-      labels: ['Type: Documentation']
+      labels: ["Type: Documentation"]
     - title: Refactoring
-      labels: ['Type: Refactoring']
+      labels: ["Type: Refactoring"]
     - title: Testing
-      labels: ['Type: Testing']
+      labels: ["Type: Testing"]
     - title: Maintenance
-      labels: ['Type: Maintenance']
+      labels: ["Type: Maintenance"]
     - title: CI
-      labels: ['Type: CI']
+      labels: ["Type: CI"]
     - title: Dependency Updates
-      labels: ['Type: Dependencies', "dependencies"]
+      labels: ["Type: Dependencies", "dependencies"]
     - title: Other Changes
-      labels: ['*']
+      labels: ["*"]

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,7 +1,7 @@
 name: release
 
 env:
-  DENO_VERSION: 1.x
+  DENO_VERSION: 2.x
 
 on:
   push:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,14 +7,14 @@ on:
     branches:
       - main
     paths:
-      - '**.ts'
-      - '.github/workflows/test.yml'
-      - 'deno.jsonc'
+      - "**.ts"
+      - ".github/workflows/test.yml"
+      - "deno.jsonc"
   pull_request:
     branches:
       - main
     paths:
-      - '**.ts'
+      - "**.ts"
 
 permissions:
   contents: read
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@e95548e56dfa95d4e1a28d6f422fafe75c4c26fb # v2.0.3
         with:
-          deno-version: v1.x
+          deno-version: v2.x
 
       - name: Check
         run: deno task check
@@ -46,7 +46,7 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@e95548e56dfa95d4e1a28d6f422fafe75c4c26fb # v2.0.3
         with:
-          deno-version: v1.x
+          deno-version: v2.x
 
       - name: Run test with coverage report
         shell: bash
@@ -94,7 +94,7 @@ jobs:
       - run: deno publish --dry-run
 
   action-timeline:
-    needs: 
+    needs:
       - ci
       - test
       - coverage-report
@@ -102,4 +102,4 @@ jobs:
     if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
-    - uses: Kesin11/actions-timeline@a7eaabf426cdae26c3582c3fa674b897170dec8f # v2.2.4
+      - uses: Kesin11/actions-timeline@a7eaabf426cdae26c3582c3fa674b897170dec8f # v2.2.4

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@e95548e56dfa95d4e1a28d6f422fafe75c4c26fb # v2.0.3
         with:
-          deno-version: v1.x
+          deno-version: v2.x
 
       - name: Update dependencies with molt
         id: run-deno-molt


### PR DESCRIPTION
## Summary\n- Updated all GitHub workflows to use Deno v2.x instead of v1.x\n- Updated dependencies via \`deno cache --reload\`\n- Fixed formatting issues that arose during the update\n- All tests pass successfully with the new Deno version\n\n## Changes\n- Updated `.github/workflows/test.yaml` to use Deno v2.x\n- Updated `.github/workflows/release.yaml` to use Deno v2.x\n- Updated `.github/workflows/update.yaml` to use Deno v2.x\n- Refreshed deno.lock file with latest dependencies\n\n## Test Plan\n- [x] All existing tests pass\n- [x] Code linting passes\n- [x] Type checking passes\n- [x] Format checking passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores / CI**
  * Upgraded Deno runtime used in testing, update, and release pipelines to 2.x to align builds and releases with the latest environment.
  * No changes to workflow triggers or job structure beyond the version update.

* **Style**
  * Standardized quoting in release configuration for consistency; no behavioral impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->