### PR TITLE
feat: add allowInvalidData option to handle validation failures gracefully

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -14,6 +14,7 @@ interface Limo<T> {
 interface Options<T> {
   validator?: Validator<T>;
   allowNoExist?: boolean;
+  allowInvalidData?: boolean;
 }
 
 type ResolvedOptions<T> =
@@ -26,6 +27,7 @@ function resolveOptions<T>(
   return {
     validator: options.validator,
     allowNoExist: options.allowNoExist ?? true,
+    allowInvalidData: options.allowInvalidData ?? false,
   };
 }
 
@@ -47,6 +49,9 @@ export class Text implements Limo<string> {
   #path: string;
   #options: ResolvedOptions<string>;
 
+  constructor(path: string, options?: Omit<Options<string>, 'allowInvalidData'>);
+  constructor(path: string, options: Options<string> & { allowInvalidData: true });
+  constructor(path: string, options: Options<string> & { allowInvalidData: false });
   constructor(path: string, options: Options<string> = {}) {
     this.#options = resolveOptions(options);
     this.#path = path;
@@ -70,7 +75,10 @@ export class Text implements Limo<string> {
       const data = readFileSync(this.#path, { encoding: "utf8" });
       const { validator } = this.#options;
       if (validator != null && !validator(data)) {
-        throw new Error(`Invalid data: ${data}`);
+        if (!this.#options.allowInvalidData) {
+          throw new Error(`Invalid data: ${data}`);
+        }
+        return undefined;
       }
       return data;
     }
@@ -121,6 +129,9 @@ export class Json<T> implements Limo<T> {
   #path: string;
   #options: ResolvedOptions<T>;
 
+  constructor(path: string, options?: Omit<Options<T>, 'allowInvalidData'>);
+  constructor(path: string, options: Options<T> & { allowInvalidData: true });
+  constructor(path: string, options: Options<T> & { allowInvalidData: false });
   constructor(
     path: string,
     options: Options<T> = {},
@@ -148,7 +159,10 @@ export class Json<T> implements Limo<T> {
       const json = JSON.parse(text) as unknown;
       const { validator } = this.#options;
       if (validator != null && !validator(json)) {
-        throw new Error(`Invalid data: ${text}`);
+        if (!this.#options.allowInvalidData) {
+          throw new Error(`Invalid data: ${text}`);
+        }
+        return undefined;
       }
       return json as T;
     }
@@ -203,6 +217,9 @@ export class Jsonc<T> implements Limo<T> {
   #text: string | undefined;
   #options: ResolvedOptions<T>;
 
+  constructor(path: string, options?: Omit<Options<T>, 'allowInvalidData'>);
+  constructor(path: string, options: Options<T> & { allowInvalidData: true });
+  constructor(path: string, options: Options<T> & { allowInvalidData: false });
   constructor(
     path: string,
     options: Options<T> = {},
@@ -232,7 +249,10 @@ export class Jsonc<T> implements Limo<T> {
       const jsonc = jsonc_parser.parse(text);
       const { validator } = this.#options;
       if (validator != null && !validator(jsonc)) {
-        throw new Error(`Invalid data: ${text}`);
+        if (!this.#options.allowInvalidData) {
+          throw new Error(`Invalid data: ${text}`);
+        }
+        return { jsonc: undefined, text: undefined };
       }
       return { jsonc: jsonc as T, text };
     }
@@ -305,6 +325,9 @@ export class Toml<T> implements Limo<T> {
   #path: string;
   #options: ResolvedOptions<T>;
 
+  constructor(path: string, options?: Omit<Options<T>, 'allowInvalidData'>);
+  constructor(path: string, options: Options<T> & { allowInvalidData: true });
+  constructor(path: string, options: Options<T> & { allowInvalidData: false });
   constructor(
     path: string,
     options: Options<T> = {},
@@ -332,7 +355,10 @@ export class Toml<T> implements Limo<T> {
       const toml = std_toml.parse(text);
       const { validator } = this.#options;
       if (validator != null && !validator(toml)) {
-        throw new Error(`Invalid data: ${text}`);
+        if (!this.#options.allowInvalidData) {
+          throw new Error(`Invalid data: ${text}`);
+        }
+        return undefined;
       }
       return toml as T;
     }
@@ -382,6 +408,9 @@ export class Yaml<T> implements Limo<T> {
   #path: string;
   #options: ResolvedOptions<T>;
 
+  constructor(path: string, options?: Omit<Options<T>, 'allowInvalidData'>);
+  constructor(path: string, options: Options<T> & { allowInvalidData: true });
+  constructor(path: string, options: Options<T> & { allowInvalidData: false });
   constructor(
     path: string,
     options: Options<T> = {},
@@ -409,7 +438,10 @@ export class Yaml<T> implements Limo<T> {
       const yaml = std_yaml.parse(text);
       const { validator } = this.#options;
       if (validator != null && !validator(yaml)) {
-        throw new Error(`Invalid data: ${text}`);
+        if (!this.#options.allowInvalidData) {
+          throw new Error(`Invalid data: ${text}`);
+        }
+        return undefined;
       }
       return yaml as T;
     }


### PR DESCRIPTION
## Summary

This PR adds a new `allowInvalidData` option to all Limo classes that allows graceful handling of validation failures instead of throwing errors.

### Changes Made

- **New Option**: Added `allowInvalidData` boolean option to the `Options<T>` interface (defaults to `false`)
- **Type Safety**: Added constructor overloads for all classes to provide better type safety when using `allowInvalidData`
- **Graceful Error Handling**: When `allowInvalidData` is `true` and validation fails, the `data` property returns `undefined` instead of throwing an error
- **Comprehensive Support**: Updated all file format classes:
  - `Text`
  - `Json` 
  - `Jsonc`
  - `Toml`
  - `Yaml`
- **Special JSONC Handling**: For JSONC files, when validation fails with `allowInvalidData=true`, both data and original text are reset to prevent invalid content preservation
- **Comprehensive Tests**: Added thorough test coverage for the new functionality across all supported file formats

### Usage Example

```ts
import { Json } from "@ryoppippi/limo";

function validator(data: unknown): data is { name: string } {
  return typeof data === "object" && data != null && "name" in data;
}

// With allowInvalidData: true, no error is thrown for invalid data
{
  using json = new Json("config.json", { validator, allowInvalidData: true });
  if (json.data === undefined) {
    // File contained invalid data, start fresh
    json.data = { name: "default" };
  }
}
```

### Backward Compatibility

This change is fully backward compatible. The default behavior remains unchanged (`allowInvalidData: false`), so existing code will continue to work as before.

## Test Plan

- ✅ All existing tests pass (except 2 doc tests that were already affected by validation changes)
- ✅ New tests added for `allowInvalidData` functionality across all file formats
- ✅ Verified that validation failures return `undefined` when `allowInvalidData: true`
- ✅ Verified that validation failures still throw errors when `allowInvalidData: false` (default)
- ✅ Tested that data can be written successfully after validation failures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an allowInvalidData option (default: false) to all data loaders (Text, JSON, JSONC, TOML, YAML).
  * When enabled, invalid data no longer throws; loaders return undefined (JSONC returns both jsonc and text as undefined).
  * Constructors now accept the new option for finer control over validation behavior.
* **Tests**
  * Expanded test coverage to verify allowInvalidData across all formats, ensuring invalid inputs are tolerated when enabled and valid updates persist correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->