### PR TITLE
feat: replace manual tmpdir setup with fs-fixture and await using

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -22,7 +22,8 @@
     "@std/jsonc": "jsr:@std/jsonc@^1.0.0",
     "@std/toml": "jsr:@std/toml@^1.0.0",
     "@std/yaml": "jsr:@std/yaml@^1.0.0",
-    "jsonc-parser": "npm:jsonc-parser@^3.2.1"
+    "jsonc-parser": "npm:jsonc-parser@^3.2.1",
+    "fs-fixture": "npm:fs-fixture@^1.2.0"
   },
   "exports": "./mod.ts",
   "publish": {

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -23,7 +23,7 @@
     "@std/toml": "jsr:@std/toml@^1.0.0",
     "@std/yaml": "jsr:@std/yaml@^1.0.0",
     "jsonc-parser": "npm:jsonc-parser@^3.2.1",
-    "fs-fixture": "npm:fs-fixture@^1.2.0"
+    "fs-fixture": "npm:fs-fixture@^2.8.1"
   },
   "exports": "./mod.ts",
   "publish": {

--- a/deno.lock
+++ b/deno.lock
@@ -17,7 +17,7 @@
     "jsr:@std/yaml@1": "1.0.9",
     "npm:@types/node@*": "18.16.19",
     "npm:cronstrue@*": "2.50.0",
-    "npm:fs-fixture@^1.2.0": "1.2.0",
+    "npm:fs-fixture@^2.8.1": "2.8.1",
     "npm:jsonc-parser@^3.2.1": "3.3.1"
   },
   "jsr": {
@@ -94,8 +94,8 @@
       "integrity": "sha512-ULYhWIonJzlScCCQrPUG5uMXzXxSixty4djud9SS37DoNxDdkeRocxzHuAo4ImRBUK+mAuU5X9TSwEDccnnuPg==",
       "bin": true
     },
-    "fs-fixture@1.2.0": {
-      "integrity": "sha512-bPBNW12US81zxCXzP/BQ6ntSvMXNgX76nHVUxzQJVTmHkzXnbfp+M4mNWeJ9LuCG8M1wyeFov7oiwO9wnCEBjQ=="
+    "fs-fixture@2.8.1": {
+      "integrity": "sha512-C0xA7XvqZBbbOgitWcMDstfih8GaOPEyXfvNefmV7+1573TCnFQ6hAJEUEzH2LVrscONLh73rvayNfa/m9PMgw=="
     },
     "jsonc-parser@3.3.1": {
       "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ=="
@@ -108,7 +108,7 @@
       "jsr:@std/jsonc@1",
       "jsr:@std/toml@1",
       "jsr:@std/yaml@1",
-      "npm:fs-fixture@^1.2.0",
+      "npm:fs-fixture@^2.8.1",
       "npm:jsonc-parser@^3.2.1"
     ]
   }

--- a/deno.lock
+++ b/deno.lock
@@ -1,98 +1,114 @@
 {
-  "version": "3",
-  "packages": {
-    "specifiers": {
-      "jsr:@cross/runtime@^1.0.0": "jsr:@cross/runtime@1.1.0",
-      "jsr:@cross/test@^0.0.10": "jsr:@cross/test@0.0.10",
-      "jsr:@std/assert@^1.0.0": "jsr:@std/assert@1.0.14",
-      "jsr:@std/bytes@^1.0.5": "jsr:@std/bytes@1.0.6",
-      "jsr:@std/collections@^1.1.3": "jsr:@std/collections@1.1.3",
-      "jsr:@std/internal@^1.0.10": "jsr:@std/internal@1.0.10",
-      "jsr:@std/json@^1.0.2": "jsr:@std/json@1.0.2",
-      "jsr:@std/jsonc@^1.0.0": "jsr:@std/jsonc@1.0.2",
-      "jsr:@std/streams@^1.0.9": "jsr:@std/streams@1.0.9",
-      "jsr:@std/toml@^1.0.0": "jsr:@std/toml@1.0.9",
-      "jsr:@std/yaml@^1.0.0": "jsr:@std/yaml@1.0.9",
-      "npm:@types/node": "npm:@types/node@18.16.19",
-      "npm:cronstrue": "npm:cronstrue@2.50.0",
-      "npm:jsonc-parser@^3.2.1": "npm:jsonc-parser@3.3.1"
+  "version": "5",
+  "specifiers": {
+    "jsr:@cross/runtime@1": "1.1.0",
+    "jsr:@cross/test@^0.0.10": "0.0.10",
+    "jsr:@std/assert@1": "1.0.14",
+    "jsr:@std/bytes@^1.0.5": "1.0.6",
+    "jsr:@std/collections@^1.1.3": "1.1.3",
+    "jsr:@std/fs@*": "1.0.19",
+    "jsr:@std/internal@^1.0.10": "1.0.10",
+    "jsr:@std/internal@^1.0.9": "1.0.10",
+    "jsr:@std/json@^1.0.2": "1.0.2",
+    "jsr:@std/jsonc@1": "1.0.2",
+    "jsr:@std/path@^1.1.1": "1.1.1",
+    "jsr:@std/streams@^1.0.9": "1.0.9",
+    "jsr:@std/toml@1": "1.0.9",
+    "jsr:@std/yaml@1": "1.0.9",
+    "npm:@types/node@*": "18.16.19",
+    "npm:cronstrue@*": "2.50.0",
+    "npm:fs-fixture@^1.2.0": "1.2.0",
+    "npm:jsonc-parser@^3.2.1": "3.3.1"
+  },
+  "jsr": {
+    "@cross/runtime@1.1.0": {
+      "integrity": "f35a3b768a9de125277329483b684062ffc9ee86f4449cb8b3d614adcad64ffb"
     },
-    "jsr": {
-      "@cross/runtime@1.1.0": {
-        "integrity": "f35a3b768a9de125277329483b684062ffc9ee86f4449cb8b3d614adcad64ffb"
-      },
-      "@cross/test@0.0.10": {
-        "integrity": "5f235cdd927d5551d692bc413458625552d299bc5471baf18180e4287cf4ac20",
-        "dependencies": [
-          "jsr:@cross/runtime@^1.0.0"
-        ]
-      },
-      "@std/assert@1.0.14": {
-        "integrity": "68d0d4a43b365abc927f45a9b85c639ea18a9fab96ad92281e493e4ed84abaa4",
-        "dependencies": [
-          "jsr:@std/internal@^1.0.10"
-        ]
-      },
-      "@std/bytes@1.0.6": {
-        "integrity": "f6ac6adbd8ccd99314045f5703e23af0a68d7f7e58364b47d2c7f408aeb5820a"
-      },
-      "@std/collections@1.1.3": {
-        "integrity": "bf8b0818886df6a32b64c7d3b037a425111f28278d69fd0995aeb62777c986b0"
-      },
-      "@std/internal@1.0.10": {
-        "integrity": "e3be62ce42cab0e177c27698e5d9800122f67b766a0bea6ca4867886cbde8cf7"
-      },
-      "@std/json@1.0.2": {
-        "integrity": "d9e5497801c15fb679f55a2c01c7794ad7a5dfda4dd1bebab5e409cb5e0d34d4",
-        "dependencies": [
-          "jsr:@std/streams@^1.0.9"
-        ]
-      },
-      "@std/jsonc@1.0.2": {
-        "integrity": "909605dae3af22bd75b1cbda8d64a32cf1fd2cf6efa3f9e224aba6d22c0f44c7",
-        "dependencies": [
-          "jsr:@std/json@^1.0.2"
-        ]
-      },
-      "@std/streams@1.0.9": {
-        "integrity": "a9d26b1988cdd7aa7b1f4b51e1c36c1557f3f252880fa6cc5b9f37078b1a5035",
-        "dependencies": [
-          "jsr:@std/bytes@^1.0.5"
-        ]
-      },
-      "@std/toml@1.0.9": {
-        "integrity": "1629147c2edbffd71be6ab66cf90d3b27e59ca314067e58649e0626979383b83",
-        "dependencies": [
-          "jsr:@std/collections@^1.1.3"
-        ]
-      },
-      "@std/yaml@1.0.9": {
-        "integrity": "6bad3dc766dd85b4b37eabcba81b6aa4eac7a392792ae29abcfb0f90602d55bb"
-      }
+    "@cross/test@0.0.10": {
+      "integrity": "5f235cdd927d5551d692bc413458625552d299bc5471baf18180e4287cf4ac20",
+      "dependencies": [
+        "jsr:@cross/runtime"
+      ]
     },
-    "npm": {
-      "@types/node@18.16.19": {
-        "integrity": "sha512-IXl7o+R9iti9eBW4Wg2hx1xQDig183jj7YLn8F7udNceyfkbn1ZxmzZXuak20gR40D7pIkIY1kYGx5VIGbaHKA==",
-        "dependencies": {}
-      },
-      "cronstrue@2.50.0": {
-        "integrity": "sha512-ULYhWIonJzlScCCQrPUG5uMXzXxSixty4djud9SS37DoNxDdkeRocxzHuAo4ImRBUK+mAuU5X9TSwEDccnnuPg==",
-        "dependencies": {}
-      },
-      "jsonc-parser@3.3.1": {
-        "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
-        "dependencies": {}
-      }
+    "@std/assert@1.0.14": {
+      "integrity": "68d0d4a43b365abc927f45a9b85c639ea18a9fab96ad92281e493e4ed84abaa4",
+      "dependencies": [
+        "jsr:@std/internal@^1.0.10"
+      ]
+    },
+    "@std/bytes@1.0.6": {
+      "integrity": "f6ac6adbd8ccd99314045f5703e23af0a68d7f7e58364b47d2c7f408aeb5820a"
+    },
+    "@std/collections@1.1.3": {
+      "integrity": "bf8b0818886df6a32b64c7d3b037a425111f28278d69fd0995aeb62777c986b0"
+    },
+    "@std/fs@1.0.19": {
+      "integrity": "051968c2b1eae4d2ea9f79a08a3845740ef6af10356aff43d3e2ef11ed09fb06",
+      "dependencies": [
+        "jsr:@std/internal@^1.0.9",
+        "jsr:@std/path"
+      ]
+    },
+    "@std/internal@1.0.10": {
+      "integrity": "e3be62ce42cab0e177c27698e5d9800122f67b766a0bea6ca4867886cbde8cf7"
+    },
+    "@std/json@1.0.2": {
+      "integrity": "d9e5497801c15fb679f55a2c01c7794ad7a5dfda4dd1bebab5e409cb5e0d34d4",
+      "dependencies": [
+        "jsr:@std/streams"
+      ]
+    },
+    "@std/jsonc@1.0.2": {
+      "integrity": "909605dae3af22bd75b1cbda8d64a32cf1fd2cf6efa3f9e224aba6d22c0f44c7",
+      "dependencies": [
+        "jsr:@std/json"
+      ]
+    },
+    "@std/path@1.1.1": {
+      "integrity": "fe00026bd3a7e6a27f73709b83c607798be40e20c81dde655ce34052fd82ec76",
+      "dependencies": [
+        "jsr:@std/internal@^1.0.9"
+      ]
+    },
+    "@std/streams@1.0.9": {
+      "integrity": "a9d26b1988cdd7aa7b1f4b51e1c36c1557f3f252880fa6cc5b9f37078b1a5035",
+      "dependencies": [
+        "jsr:@std/bytes"
+      ]
+    },
+    "@std/toml@1.0.9": {
+      "integrity": "1629147c2edbffd71be6ab66cf90d3b27e59ca314067e58649e0626979383b83",
+      "dependencies": [
+        "jsr:@std/collections"
+      ]
+    },
+    "@std/yaml@1.0.9": {
+      "integrity": "6bad3dc766dd85b4b37eabcba81b6aa4eac7a392792ae29abcfb0f90602d55bb"
     }
   },
-  "remote": {},
+  "npm": {
+    "@types/node@18.16.19": {
+      "integrity": "sha512-IXl7o+R9iti9eBW4Wg2hx1xQDig183jj7YLn8F7udNceyfkbn1ZxmzZXuak20gR40D7pIkIY1kYGx5VIGbaHKA=="
+    },
+    "cronstrue@2.50.0": {
+      "integrity": "sha512-ULYhWIonJzlScCCQrPUG5uMXzXxSixty4djud9SS37DoNxDdkeRocxzHuAo4ImRBUK+mAuU5X9TSwEDccnnuPg==",
+      "bin": true
+    },
+    "fs-fixture@1.2.0": {
+      "integrity": "sha512-bPBNW12US81zxCXzP/BQ6ntSvMXNgX76nHVUxzQJVTmHkzXnbfp+M4mNWeJ9LuCG8M1wyeFov7oiwO9wnCEBjQ=="
+    },
+    "jsonc-parser@3.3.1": {
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ=="
+    }
+  },
   "workspace": {
     "dependencies": [
       "jsr:@cross/test@^0.0.10",
-      "jsr:@std/assert@^1.0.0",
-      "jsr:@std/jsonc@^1.0.0",
-      "jsr:@std/toml@^1.0.0",
-      "jsr:@std/yaml@^1.0.0",
+      "jsr:@std/assert@1",
+      "jsr:@std/jsonc@1",
+      "jsr:@std/toml@1",
+      "jsr:@std/yaml@1",
+      "npm:fs-fixture@^1.2.0",
       "npm:jsonc-parser@^3.2.1"
     ]
   }

--- a/mod_test.ts
+++ b/mod_test.ts
@@ -1,8 +1,6 @@
 import { test } from "@cross/test";
 import { assertEquals } from "@std/assert";
 
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
 import * as jsonc_parser from "jsonc-parser";
 import * as std_yaml from "@std/yaml";
 import { createFixture } from "fs-fixture";
@@ -17,32 +15,32 @@ import {
 
 test("createLimoText", async () => {
   await using fixture = await createFixture({});
-  const filepath = join(fixture.path, "file.txt");
+  const filepath = fixture.getPath("file.txt");
   {
     using text = createLimoText(filepath);
     text.data = "Hello, World!";
   }
 
-  const data = readFileSync(filepath, "utf-8");
+  const data = await fixture.readFile("file.txt", "utf-8");
   assertEquals(data, "Hello, World!");
 });
 
 test("createLimoJson without validator", async () => {
   await using fixture = await createFixture({});
-  const filepath = join(fixture.path, "file.json");
+  const filepath = fixture.getPath("file.json");
   {
     using json = createLimoJson(filepath);
     json.data = { hello: "world" };
   }
 
-  const data = readFileSync(filepath, "utf-8");
+  const data = await fixture.readFile("file.json", "utf-8");
   const json = JSON.parse(data);
   assertEquals(json, { hello: "world" });
 });
 
 test("createLimoJson with validator", async () => {
   await using fixture = await createFixture({});
-  const filepath = join(fixture.path, "file.json");
+  const filepath = fixture.getPath("file.json");
 
   function validator(data: unknown): data is { hello: string } {
     return typeof data === "object" && data != null && "hello" in data;
@@ -52,20 +50,20 @@ test("createLimoJson with validator", async () => {
     json.data = { hello: "world" };
   }
 
-  const data = readFileSync(filepath, "utf-8");
+  const data = await fixture.readFile("file.json", "utf-8");
   const json = JSON.parse(data);
   assertEquals(json, { hello: "world" });
 });
 
 test("createLimoJsonc without validator", async () => {
   await using fixture = await createFixture({});
-  const filepath = join(fixture.path, "file.jsonc");
+  const filepath = fixture.getPath("file.jsonc");
   {
     using json = createLimoJsonc(filepath);
     json.data = { hello: "world" };
   }
 
-  const data = readFileSync(filepath, "utf-8");
+  const data = await fixture.readFile("file.jsonc", "utf-8");
   const jsonc = jsonc_parser.parse(data);
   assertEquals(jsonc, { hello: "world" });
 });
@@ -74,7 +72,7 @@ test("createLimoJsonc with prepared file and format preservation", async () => {
   await using fixture = await createFixture({
     "file.jsonc": '{"hello": "world"} // comment'
   });
-  const filepath = join(fixture.path, "file.jsonc");
+  const filepath = fixture.getPath("file.jsonc");
 
   function validator(data: unknown): data is { hello?: string; foo?: string } {
     return typeof data === "object" && data != null && "hello" in data;
@@ -86,26 +84,26 @@ test("createLimoJsonc with prepared file and format preservation", async () => {
     json.data = { foo: "bar" };
   }
 
-  const data = readFileSync(filepath, "utf-8");
+  const data = await fixture.readFile("file.jsonc", "utf-8");
   const jsonc = jsonc_parser.parse(data);
   assertEquals(jsonc, { foo: "bar" });
 });
 
 test("createLimoToml", async () => {
   await using fixture = await createFixture({});
-  const filepath = join(fixture.path, "file.toml");
+  const filepath = fixture.getPath("file.toml");
   {
     using toml = createLimoToml(filepath);
     toml.data = { hello: "world" };
   }
 
-  const data = readFileSync(filepath, "utf-8");
+  const data = await fixture.readFile("file.toml", "utf-8");
   assertEquals(data, 'hello = "world"\n');
 });
 
 test("createLimoToml with validator", async () => {
   await using fixture = await createFixture({});
-  const filepath = join(fixture.path, "file.toml");
+  const filepath = fixture.getPath("file.toml");
 
   function validator(data: unknown): data is { hello: string } {
     return typeof data === "object" && data != null && "hello" in data;
@@ -115,25 +113,25 @@ test("createLimoToml with validator", async () => {
     toml.data = { hello: "world" };
   }
 
-  const data = readFileSync(filepath, "utf-8");
+  const data = await fixture.readFile("file.toml", "utf-8");
   assertEquals(data, 'hello = "world"\n');
 });
 
 test("createLimoYaml", async () => {
   await using fixture = await createFixture({});
-  const filepath = join(fixture.path, "file.yaml");
+  const filepath = fixture.getPath("file.yaml");
   {
     using yaml = createLimoYaml(filepath);
     yaml.data = { hello: "world" };
   }
 
-  const data = readFileSync(filepath, "utf-8");
+  const data = await fixture.readFile("file.yaml", "utf-8");
   assertEquals(data, "hello: world\n");
 });
 
 test("createLimoYaml with validator", async () => {
   await using fixture = await createFixture({});
-  const filepath = join(fixture.path, "file.yaml");
+  const filepath = fixture.getPath("file.yaml");
 
   function validator(data: unknown): data is { hello: string } {
     return typeof data === "object" && data != null && "hello" in data;
@@ -143,7 +141,7 @@ test("createLimoYaml with validator", async () => {
     yaml.data = { hello: "world" };
   }
 
-  const data = readFileSync(filepath, "utf-8");
+  const data = await fixture.readFile("file.yaml", "utf-8");
   assertEquals(data, "hello: world\n");
 });
 
@@ -156,7 +154,7 @@ baz:
   - quux
 `
   });
-  const filepath = join(fixture.path, "file.yaml");
+  const filepath = fixture.getPath("file.yaml");
 
   {
     using yaml = createLimoYaml<{ foo: string; baz: string[] }>(filepath);
@@ -164,7 +162,7 @@ baz:
     yaml.data?.baz.push("corge");
   }
 
-  const data = readFileSync(filepath, "utf-8");
+  const data = await fixture.readFile("file.yaml", "utf-8");
   const yamlData = std_yaml.parse(data);
   assertEquals(yamlData, { foo: "bar", baz: ["qux", "quux", "corge"] });
 });

--- a/mod_test.ts
+++ b/mod_test.ts
@@ -1,7 +1,7 @@
 import { test } from "@cross/test";
 import { assertEquals } from "@std/assert";
 
-import { readFileSync, writeFileSync } from "node:fs";
+import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import * as jsonc_parser from "jsonc-parser";
 import * as std_yaml from "@std/yaml";


### PR DESCRIPTION
## Summary
- Replace manual temporary directory setup with fs-fixture library
- Use await using syntax for automatic cleanup
- Update fs-fixture dependency to v2.8.1

## Changes
- Modernize test utilities with fs-fixture for better temporary directory management
- Implement await using for automatic resource cleanup
- Update dependency version for latest features and improvements

## Test plan
- [x] All existing tests pass
- [x] Dependency update verified